### PR TITLE
Use cflinuxfs3 stack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,4 +4,5 @@ applications:
   host: dgu-ckan
   domain: data.gov.uk
   buildpack: https://github.com/cloudfoundry/nginx-buildpack.git
+  stack: cflinuxfs3
   memory: 64M


### PR DESCRIPTION
cflinuxfs2 is being deprecated so we should upgrade to the latest stack version.

[Trello Card](https://trello.com/c/LnfsfS1q/875-upgrade-datagovuk-to-cflinuxfs3)